### PR TITLE
Removed Color Overlays that were causing icons to look wierd in plasma 6

### DIFF
--- a/contents/ui/Header.qml
+++ b/contents/ui/Header.qml
@@ -47,12 +47,7 @@ Item {
       source: "icons/feather/settings.svg"
       width: iconSize
       height: width
-      ColorOverlay {
-        visible: plasmoid.configuration.theming != 0
-        anchors.fill: settingsImage
-        source: settingsImage
-        color: main.textColor
-      }
+   
     }
     onClicked: {
       KQuickAddons.KCMShell.openSystemSettings("kcm_quick")
@@ -78,12 +73,6 @@ Item {
       source: "icons/feather/power.svg"
       width: iconSize
       height: width
-      ColorOverlay {
-        visible: true
-        anchors.fill: powerImage
-        source: powerImage
-        color: main.textColor
-      }
     }
     onClicked: {
       pmEngine.performOperation("requestShutDown")

--- a/contents/ui/MainView.qml
+++ b/contents/ui/MainView.qml
@@ -172,12 +172,7 @@ Item {
         height: width
         anchors.verticalCenter: parent.verticalCenter
         source: 'icons/feather/search.svg'
-        ColorOverlay {
-          visible: true
-          anchors.fill: searchIcon
-          source: searchIcon
-          color: main.textColor
-        }
+       
       }
       Rectangle {
         x: 45 * PlasmaCore.Units.devicePixelRatio
@@ -271,12 +266,6 @@ Item {
       font.pointSize: textSize
     }
 
-    ColorOverlay {
-      visible: true
-      anchors.fill: headerLabel
-      source: headerLabel
-      color: main.textColor
-    }
   }
   // Show all app buttons
   PlasmaComponents.Button  {


### PR DESCRIPTION
I don't know what these were for but they don't seem to be necessary.