### PR TITLE
fix: bug Plasmoid.status

### DIFF
--- a/contents/ui/MenuRepresentation.qml
+++ b/contents/ui/MenuRepresentation.qml
@@ -24,6 +24,7 @@ import QtQuick 2.12
 import QtQuick.Layouts 1.12
 import org.kde.plasma.core 2.0 as PlasmaCore
 import org.kde.plasma.components 3.0 as PlasmaComponents
+import org.kde.plasma.plasmoid 2.0
 
 PlasmaCore.Dialog {
     id: root
@@ -32,8 +33,10 @@ PlasmaCore.Dialog {
     flags: Qt.WindowStaysOnTopHint
 
     location: plasmoid.configuration.floating || plasmoid.configuration.launcherPosition == 2 ? "Floating" : plasmoid.location
-
+    
     hideOnWindowDeactivate: true
+
+    Plasmoid.status: root.visible ? PlasmaCore.Types.RequiresAttentionStatus : PlasmaCore.Types.PassiveStatus
 
     onVisibleChanged: {
         if (!visible) {


### PR DESCRIPTION
Currently the plasmoid has a bug that causes the panel to disappear under certain circumstances.

To replicate the bug I need to have a panel configured to dodge windows, have a window maximized and open the menu, the menu will remain visible while the panel disappears.

With the addition of this commit this is fixed